### PR TITLE
Use heroku port or 3000

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const { Server } = require("socket.io");
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 app.use(express.static(__dirname + '/public'));
 


### PR DESCRIPTION
Heroku auto assigns a port, so we cannot use a fixed port (i.e. 3000).